### PR TITLE
Added option for generating UML class diagrams

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -3,18 +3,18 @@ var path = require("path");
 var fs = require("fs");
 var pako = require("pako");
 var encode64 = require("./encode64");
-var Converter = require("typedoc").Converter;
 
-function plugin (plugins, cb) {
+function plugin (pluginHost, cb) {
 
     var umlExpression = /<uml(?:\s+alt\s*=\s*['"](.+)['"]\s*)?>([\s\S]*?)<\/uml>/gi,
-        encodedUmlExpression = /<img src="http:\/\/www.plantuml.com\/plantuml\/(?:img|png|svg)\/([^"]*)"(?: alt="(.*)")?>/g,
+        encodedUmlExpression = /<img src="http:\/\/www\.plantuml\.com\/plantuml\/(?:img|png|svg)\/([^"]*)"(?: alt="(.*)")?>/g,
         outputDirectory,
         server = "http://www.plantuml.com/plantuml/",
         format,
-        location;
+        location,
+        addClassDiagramPosition;
 
-    var app = plugins.application;
+    var app = pluginHost.application;
 
     // setup options
     app.options.addDeclaration({
@@ -29,40 +29,170 @@ function plugin (plugins, cb) {
         defaultValue: 'png'
     });
 
+    app.options.addDeclaration({
+        name: 'umlAddClassDiagram',
+        help: 'above|below',
+        defaultValue: null
+    });
+
     // on resolve replace uml blocks with image link to encoded uml data
-    app.converter.on("resolveBegin", function (context) {
+    app.converter.on("resolveEnd", function (context) {
 
         // ensure valid format
         format = app.options.getValue("umlFormat");
-        if(format) {
+        if (format) {
             format = format.toLowerCase();
         }
-        if(format != "png" && format != "svg") {
+        if (format != "png" && format != "svg") {
             format = "png";
         }
 
         // ensure valid location
         location = app.options.getValue("umlLocation");
-        if(location) {
+        if (location) {
             location = location.toLowerCase();
         }
-        if(location != "local" && location != "remote") {
+        if (location != "local" && location != "remote") {
             location = "local";
+        }
+
+        // check if class diagrams should be generated
+        addClassDiagramPosition = app.options.getValue("umlAddClassDiagram");
+        if (addClassDiagramPosition) {
+            addClassDiagramPosition = addClassDiagramPosition.toLowerCase();
+
+            if (addClassDiagramPosition != "above" && addClassDiagramPosition != "below") {
+                addClassDiagramPosition = "below";
+            }
         }
 
         var project = context.project;
 
-        // go though all the comments
+        // go through all the comments
         for (var key in project.reflections) {
             var reflection = project.reflections[key];
 
             if(reflection.comment) {
+                // add UML tag for class diagram only for classes and interfaces
+                if (addClassDiagramPosition && (reflection.kind == 128 || reflection.kind == 256)) {
+                    addClassDiagramToComment(reflection);
+                }
+    
+                // convert UML tags to PlantUML image links
                 reflection.comment.shortText = processText(reflection.comment.shortText);
                 reflection.comment.text = processText(reflection.comment.text);
             }
         }
     });
 
+    /**
+     * Returns the names of all interfaces the given class implements.
+     * This also includes interfaces the base classes of the class are implementing.
+     * @param {Reflection} reflection The class whoes interfaces are requested.
+     * @returns {string[]} The names of all interfaces the class implements.
+     */
+    function getAllInterfaceNamesForClass(reflection) {
+        var names = [];
+
+        if (reflection.implementedTypes) {
+            for (var i = 0; i < reflection.implementedTypes.length; ++i) {
+                names.push(reflection.implementedTypes[i].name);
+            }
+        }
+
+        return names;
+    }
+
+    /**
+     * Returns the names of the interfaces the given class implements.
+     * This excludes interfaces the base classes are implementing.
+     * @param {Reflection} reflection The class whoes interfaces are requested.
+     * @returns {string[]} The names of the interfaces the class implements.
+     */
+    function getInterfaceNamesForClass(reflection) {
+        var names = [];
+
+        // build list of all implemented interfaces
+        names = getAllInterfaceNamesForClass(reflection);
+
+        if (reflection.extendedTypes) {
+            // remove names of interfaces the base classes are implementing
+            for (var i = 0; i < reflection.extendedTypes.length; ++i) {
+                var baseClass = reflection.extendedTypes[i].reflection;
+                var baseClassImplements = getAllInterfaceNamesForClass(baseClass);
+
+                for (var j = 0; j < baseClassImplements.length; ++j) {
+                    if (names.indexOf(baseClassImplements[j]) != -1) {
+                        names.splice(j, 1);
+
+                        if (names.length == 0) {
+                            return [];
+                        }
+                    }
+                }
+            }
+        }
+
+        return names;
+    }
+
+    /**
+     * Creates a UML-tag with a class diagram in the comment of the reflection.
+     * @param {Reflection} reflection The reflection whoes comment is extended.
+     */
+    function addClassDiagramToComment(reflection) {
+        var umlLines = ["<uml>"];
+
+        // add class/interface
+        if (reflection.kind == 128) {
+            umlLines.push("class " + reflection.name);
+        } else if (reflection.kind == 256) {
+            umlLines.push("interface " + reflection.name);
+        }
+
+        // add extended base classes and interfaces
+        if (reflection.extendedTypes) {
+            for (var i = 0; i < reflection.extendedTypes.length; ++i) {
+                var extendedType = reflection.extendedTypes[i];
+
+                if (extendedType.reflection) {
+                    if (extendedType.reflection.kind == 128) {
+                        umlLines.push("class " + extendedType.name);
+                    } else if (extendedType.reflection.kind == 256) {
+                        umlLines.push("interface " + extendedType.name);
+                    }
+                }
+
+                umlLines.push(extendedType.name + " <|-- " + reflection.name);
+            }
+        }
+
+        // add implemented interfaces
+        if (reflection.kind == 128) {
+            var interfaceNames = getInterfaceNamesForClass(reflection);
+
+            for (var i = 0; i < interfaceNames.length; ++i) {
+                umlLines.push("interface " + interfaceNames[i]);
+                umlLines.push(interfaceNames[i] + " <|.. " + reflection.name);
+            }
+        }
+
+        umlLines.push("</uml>");
+
+        // Where to put the UML tag?
+        if (addClassDiagramPosition == "above") {
+            // the two spaces are necessary to generate a line break in markdown
+            reflection.comment.shortText = umlLines.join("\n") + "  \n" + reflection.comment.shortText;
+        } else {
+            reflection.comment.text = reflection.comment.text + "\n" + umlLines.join("\n");
+        }
+    }
+
+    /**
+     * Replaces UML-tags in a comment with Markdown image links.
+     * @param {string} text The text of the comment to process.
+     * @returns {string} The processed text of the comment.
+     */
     function processText(text) {
         var match,
             index = 0,


### PR DESCRIPTION
Use the new option `--umlAddClassDiagram` to automatically add UML class diagrams to classes and interfaces.

Here is how it works:

1. Specify the option `--umlAddClassDiagram` (value = `above|below`) when executing TypeDoc.
2. If the option is specified a `<uml>` tag is added to the comment of the class/interface. The tag includes a basic class diagram showing the class/interface and its extended/implemented types.
3. The plugin goes on as usual and creates an image from the tag.